### PR TITLE
Refactor topicID to Topic class in Target model

### DIFF
--- a/target-app/Home/Models/Target.swift
+++ b/target-app/Home/Models/Target.swift
@@ -12,13 +12,13 @@ struct Target: Codable {
     let id: Int
     let title: String
     let latitude, longitude, radius: Double
-    let topicID: Int
+    let topic: Topic
     
     private enum CodingKeys: String, CodingKey {
         case id
         case title
         case latitude, longitude, radius
-        case topicID = "topic_id"
+        case topic
     }
 }
 
@@ -56,5 +56,16 @@ struct Avatar: Codable {
         case originalURL = "original_url"
         case normalURL = "normal_url"
         case smallThumbURL = "small_thumb_url"
+    }
+}
+
+// MARK: - Topic
+struct Topic: Codable {
+    let id: Int
+    let icon, label: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case icon, label
     }
 }


### PR DESCRIPTION
- Changed topic field from `Int` to `Topic` class according to new json Target model strcuture:

```
{
  "target": {
    "id": 234,
    "title": "Test",
    "latitude": 53.36897764327445,
    "longitude": -6.276745883996698,
    "radius": 222.0,
    "topic": {
      "id": 2,
      "icon": "https://target-api-induction...7d8f/piza.jpeg",
      "label": "Pizza"
    }
  }
} 
```